### PR TITLE
Refactor: Improve modularity and DRYness of contact component styles

### DIFF
--- a/src/app/features/contact/components/contact-info/contact-info.component.scss
+++ b/src/app/features/contact/components/contact-info/contact-info.component.scss
@@ -10,16 +10,6 @@
   padding-bottom: var(--space-sm);
 }
 
-.title-gradient {
-  background: linear-gradient(90deg, var(--color-primary, #4f46e5), var(--color-secondary, #ec4899));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  color: transparent;
-  display: inline-block;
-  position: relative;
-}
-
 .contact-description {
   font-size: var(--font-size-md, 1.125rem);
   color: var(--color-text-secondary, #d1d5db);
@@ -49,4 +39,16 @@
   color: var(--color-text-secondary, #d1d5db);
   font-style: italic;
   margin-top: var(--space-lg);
+}
+
+@media (max-width: 768px) {
+  .contact-title {
+    font-size: calc(var(--text-base) * 2);
+  }
+}
+
+@media (max-width: 768px) {
+  .section-title {
+    font-size: calc(var(--text-base) * 1.5);
+  }
 }

--- a/src/app/features/contact/components/social-media-info/social-media-info.component.scss
+++ b/src/app/features/contact/components/social-media-info/social-media-info.component.scss
@@ -16,12 +16,8 @@
   }
 }
 
-.title-gradient {
-  background: linear-gradient(90deg, var(--color-primary, #4f46e5), var(--color-secondary, #ec4899));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  color: transparent;
-  display: inline-block;
-  position: relative;
+@media (max-width: 768px) {
+  .section-title {
+    font-size: calc(var(--text-base) * 1.5);
+  }
 }

--- a/src/app/features/contact/containers/contact/contact.component.scss
+++ b/src/app/features/contact/containers/contact/contact.component.scss
@@ -46,12 +46,4 @@
   :host {
     padding: var(--space-md);
   }
-  
-  .contact-title {
-    font-size: calc(var(--text-base) * 2);
-  }
-  
-  .section-title {
-    font-size: calc(var(--text-base) * 1.5);
-  }
 }

--- a/src/styles/helpers/_utilities.scss
+++ b/src/styles/helpers/_utilities.scss
@@ -9,3 +9,13 @@
   white-space: nowrap;
   border-width: 0;
 }
+
+.title-gradient {
+  background: linear-gradient(90deg, var(--color-primary, #4f46e5), var(--color-secondary, #ec4899));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  color: transparent;
+  display: inline-block;
+  position: relative;
+}


### PR DESCRIPTION

1.  Centralized `.title-gradient`:
    The duplicated `.title-gradient` class, previously found in both `contact-info.component.scss` and `social-media-info.component.scss`, has been moved to the global `src/styles/helpers/_utilities.scss` file. 

2.  Modularized Responsive Styles:
    Responsive styles for `.contact-title` and `.section-title` (specifically font size adjustments at the `max-width: 768px` breakpoint) have been moved from the parent `contact.component.scss` into the respective child components (`contact-info.component.scss` and `social-media-info.component.scss`) where these elements are defined. 
